### PR TITLE
Remove autoproperties from Color4 and Viewport types

### DIFF
--- a/src/Vortice.Win32/Numerics/Color4.cs
+++ b/src/Vortice.Win32/Numerics/Color4.cs
@@ -20,6 +20,12 @@ public readonly struct Color4
 {
 #if NET6_0_OR_GREATER
     private readonly Vector128<float> _value;
+#else
+    // Note: intentionally using fields, as autoproperties fail to compile on .NET Native (UWP)
+    private readonly float _a;
+    private readonly float _r;
+    private readonly float _g;
+    private readonly float _b;
 #endif
 
     /// <summary>
@@ -31,7 +37,7 @@ public readonly struct Color4
 #if NET6_0_OR_GREATER
         _value = Vector128.Create(value, value, value, value);
 #else
-        A = R = G = B = value;
+        _a = _r = _g = _b = value;
 #endif
     }
 
@@ -47,10 +53,10 @@ public readonly struct Color4
 #if NET6_0_OR_GREATER
         _value = Vector128.Create(red, green, blue, alpha);
 #else
-        R = red;
-        G = green;
-        B = blue;
-        A = alpha;
+        _r = red;
+        _g = green;
+        _b = blue;
+        _a = alpha;
 #endif
     }
 
@@ -63,10 +69,10 @@ public readonly struct Color4
 #if NET6_0_OR_GREATER
         _value = value.AsVector128();
 #else
-        R = value.X;
-        G = value.Y;
-        B = value.Z;
-        A = value.W;
+        _r = value.X;
+        _g = value.Y;
+        _b = value.Z;
+        _a = value.W;
 #endif
     }
 
@@ -80,10 +86,10 @@ public readonly struct Color4
 #if NET6_0_OR_GREATER
         _value = Vector128.Create(value.X, value.Y, value.Z, alpha);
 #else
-        R = value.X;
-        G = value.Y;
-        B = value.Z;
-        A = alpha;
+        _r = value.X;
+        _g = value.Y;
+        _b = value.Z;
+        _a = alpha;
 #endif
     }
 
@@ -140,16 +146,16 @@ public readonly struct Color4
     }
 #else
     /// <summary>Gets the value of the red component.</summary>
-    public float R { get; }
+    public float R => _r;
 
     /// <summary>Gets the value of the green component.</summary>
-    public float G { get; }
+    public float G => _g;
 
     /// <summary>Gets the value of the blue component.</summary>
-    public float B { get; }
+    public float B => _b;
 
     /// <summary>Gets the value of the alpha component.</summary>
-    public float A { get; }
+    public float A => _a;
 #endif
 
     public readonly float this[int index]

--- a/src/Vortice.Win32/Numerics/Viewport.cs
+++ b/src/Vortice.Win32/Numerics/Viewport.cs
@@ -19,6 +19,15 @@ namespace Win32.Numerics;
 [StructLayout(LayoutKind.Sequential, Pack = 4)]
 public readonly struct Viewport : IEquatable<Viewport>
 {
+    // Note: intentionally using fields, as autoproperties fail to compile on .NET Native (UWP).
+    // This applies to all targets (including .NET NET 6+), as there's no performance difference.
+    private readonly float _x;
+    private readonly float _y;
+    private readonly float _width;
+    private readonly float _height;
+    private readonly float _minDepth;
+    private readonly float _maxDepth;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Viewport"/> struct.
     /// </summary>
@@ -26,12 +35,12 @@ public readonly struct Viewport : IEquatable<Viewport>
     /// <param name="height">The height of the viewport in pixels.</param>
     public Viewport(float width, float height)
     {
-        X = 0.0f;
-        Y = 0.0f;
-        Width = width;
-        Height = height;
-        MinDepth = 0.0f;
-        MaxDepth = 1.0f;
+        _x = 0.0f;
+        _y = 0.0f;
+        _width = width;
+        _height = height;
+        _minDepth = 0.0f;
+        _maxDepth = 1.0f;
     }
 
     /// <summary>
@@ -43,12 +52,12 @@ public readonly struct Viewport : IEquatable<Viewport>
     /// <param name="height">The height of the viewport in pixels.</param>
     public Viewport(float x, float y, float width, float height)
     {
-        X = x;
-        Y = y;
-        Width = width;
-        Height = height;
-        MinDepth = 0.0f;
-        MaxDepth = 1.0f;
+        _x = x;
+        _y = y;
+        _width = width;
+        _height = height;
+        _minDepth = 0.0f;
+        _maxDepth = 1.0f;
     }
 
     /// <summary>
@@ -62,12 +71,12 @@ public readonly struct Viewport : IEquatable<Viewport>
     /// <param name="maxDepth">The maximum depth of the clip volume.</param>
     public Viewport(float x, float y, float width, float height, float minDepth, float maxDepth)
     {
-        X = x;
-        Y = y;
-        Width = width;
-        Height = height;
-        MinDepth = minDepth;
-        MaxDepth = maxDepth;
+        _x = x;
+        _y = y;
+        _width = width;
+        _height = height;
+        _minDepth = minDepth;
+        _maxDepth = maxDepth;
     }
 
     /// <summary>
@@ -76,12 +85,12 @@ public readonly struct Viewport : IEquatable<Viewport>
     /// <param name="bounds">A <see cref="RectangleF"/> that defines the location and size of the viewport in a render target.</param>
     public Viewport(in RectangleF bounds)
     {
-        X = bounds.X;
-        Y = bounds.Y;
-        Width = bounds.Width;
-        Height = bounds.Height;
-        MinDepth = 0.0f;
-        MaxDepth = 1.0f;
+        _x = bounds.X;
+        _y = bounds.Y;
+        _width = bounds.Width;
+        _height = bounds.Height;
+        _minDepth = 0.0f;
+        _maxDepth = 1.0f;
     }
 
     /// <summary>
@@ -90,12 +99,12 @@ public readonly struct Viewport : IEquatable<Viewport>
     /// <param name="bounds">A <see cref="Rectangle"/> that defines the location and size of the viewport in a render target.</param>
     public Viewport(in Rectangle bounds)
     {
-        X = bounds.X;
-        Y = bounds.Y;
-        Width = bounds.Width;
-        Height = bounds.Height;
-        MinDepth = 0.0f;
-        MaxDepth = 1.0f;
+        _x = bounds.X;
+        _y = bounds.Y;
+        _width = bounds.Width;
+        _height = bounds.Height;
+        _minDepth = 0.0f;
+        _maxDepth = 1.0f;
     }
 
     /// <summary>
@@ -104,43 +113,43 @@ public readonly struct Viewport : IEquatable<Viewport>
     /// <param name="bounds">A <see cref="Vector4"/> that defines the location and size of the viewport in a render target.</param>
     public Viewport(in Vector4 bounds)
     {
-        X = bounds.X;
-        Y = bounds.Y;
-        Width = bounds.Z;
-        Height = bounds.W;
-        MinDepth = 0.0f;
-        MaxDepth = 1.0f;
+        _x = bounds.X;
+        _y = bounds.Y;
+        _width = bounds.Z;
+        _height = bounds.W;
+        _minDepth = 0.0f;
+        _maxDepth = 1.0f;
     }
 
     /// <summary>
     /// Position of the pixel coordinate of the upper-left corner of the viewport.
     /// </summary>
-    public float X { get; }
+    public float X => _x;
 
     /// <summary>
     /// Position of the pixel coordinate of the upper-left corner of the viewport.
     /// </summary>
-    public float Y { get; }
+    public float Y => _y;
 
     /// <summary>
     /// Width dimension of the viewport.
     /// </summary>
-    public float Width { get; }
+    public float Width => _width;
 
     /// <summary>
     /// Height dimension of the viewport.
     /// </summary>
-    public float Height { get; }
+    public float Height => _height;
 
     /// <summary>
     /// Gets or sets the minimum depth of the clip volume.
     /// </summary>
-    public float MinDepth { get; }
+    public float MinDepth => _minDepth;
 
     /// <summary>
     /// Gets or sets the maximum depth of the clip volume.
     /// </summary>
-    public float MaxDepth { get; }
+    public float MaxDepth => _maxDepth;
 
     /// <summary>
     /// Gets or sets the bounds of the viewport.


### PR DESCRIPTION
This fixes some build errors on .NET Native (UWP).
Same changes as in https://github.com/Sergio0694/ComputeSharp/pull/377.